### PR TITLE
removed the print which was slowing down the lib

### DIFF
--- a/Fsm.cpp
+++ b/Fsm.cpp
@@ -117,7 +117,6 @@ void Fsm::check_timer()
       else
       {
         unsigned long now = millis();
-        Serial.println(now);
         if (now - transition->start >= transition->interval)
         {
           m_current_state = transition->transition.make_transition();


### PR DESCRIPTION
Small suggestion for this (very useful) library:
- The print of the elapsed millis() was perpetrating into every project that I have using the awesome arduino-fsm lib. I suggest to get rid of it, maybe we could add a 

`if(PRINT_ELAPSED_TIME) Serial.println(now);` and have a constant that devs can change in case they need to see the timings but I would say no print is better than the print. 