### PR TITLE
Make trigger function more synchronous with new parameter immidiate. …

### DIFF
--- a/Fsm.h
+++ b/Fsm.h
@@ -47,7 +47,7 @@ public:
 
   void check_timed_transitions();
 
-  void trigger(int event);
+  void trigger(int event, bool immidiate=true);
   void run_machine();
 
 private:
@@ -73,6 +73,7 @@ private:
 
 private:
   State* m_current_state;
+  Transition* m_synchronous_transition;
   Transition* m_transitions;
   int m_num_transitions;
 


### PR DESCRIPTION
Resolves issue #20 while being backward compatible.
trigger function called with trigger(EVENT,false) will queue transition until next call of run machine.
Call to trigger(EVENT,true) or trigger(EVENT) is the immediate transition while in trigger function.
