### PR TITLE
support for esp8266

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A library for implementing a finite state machine
 paragraph=Supports events for exiting and entering states.
 category=Other
 url=https://github.com/jonblack/arduino-fsm
-architectures=avr
+architectures=avr,esp8266


### PR DESCRIPTION
This is to allow seamless use of the library on the esp8266 architecture.