### PR TITLE
Add edit func

### DIFF
--- a/Fsm.cpp
+++ b/Fsm.cpp
@@ -55,12 +55,14 @@ int Fsm::add_transition(State* state_from, State* state_to, int event,
                                                on_transition);
   m_transitions = (Transition*) realloc(m_transitions, (m_num_transitions + 1)
                                                        * sizeof(Transition));
-  m_transitions[m_num_transitions] = transition;
+
+  int transition_index = m_num_transitions; // store new transition at end
+  m_transitions[transition_index] = transition;
   m_num_transitions++;
 
   // return index in list of transitions of the added transition
   // this is for consistency with add_timed_transition()
-  return (m_num_transitions - 1);
+  return transition_index;
 }
 
 
@@ -82,12 +84,14 @@ int Fsm::add_timed_transition(State* state_from, State* state_to,
 
   m_timed_transitions = (TimedTransition*) realloc(
       m_timed_transitions, (m_num_timed_transitions + 1) * sizeof(TimedTransition));
-  m_timed_transitions[m_num_timed_transitions] = timed_transition;
+
+  int transition_index = m_num_timed_transitions; // store new transition at end
+  m_timed_transitions[transition_index] = timed_transition;
   m_num_timed_transitions++;
 
   // return index in list of timed transitions of the added transition
   // this index can be passed to edit_timed_transition() to edit the transition
-  return (m_num_timed_transitions - 1);
+  return transition_index;
 }
 
 void Fsm::edit_timed_transition_interval(int index, unsigned long interval)

--- a/Fsm.cpp
+++ b/Fsm.cpp
@@ -90,7 +90,7 @@ int Fsm::add_timed_transition(State* state_from, State* state_to,
   return (m_num_timed_transitions - 1);
 }
 
-void Fsm::edit_timed_transition(unsigned long interval, int index)
+void Fsm::edit_timed_transition_interval(unsigned long interval, int index)
 {
   // Change the interval of the transition at the given index
   m_timed_transitions[index].interval = interval;

--- a/Fsm.cpp
+++ b/Fsm.cpp
@@ -90,9 +90,9 @@ int Fsm::add_timed_transition(State* state_from, State* state_to,
   return (m_num_timed_transitions - 1);
 }
 
-void Fsm::edit_timed_transition_interval(unsigned long interval, int index)
+void Fsm::edit_timed_transition_interval(int index, unsigned long interval)
 {
-  // Change the interval of the transition at the given index
+  // change the interval of the transition at the given index
   m_timed_transitions[index].interval = interval;
 
 }

--- a/Fsm.cpp
+++ b/Fsm.cpp
@@ -78,6 +78,12 @@ void Fsm::add_timed_transition(State* state_from, State* state_to,
   m_num_timed_transitions++;
 }
 
+void Fsm::edit_timed_transition(unsigned long interval, int index)
+{
+  // Change the interval of the transition at the given index
+  m_timed_transitions[index].interval = interval;
+
+}
 
 Fsm::Transition Fsm::create_transition(State* state_from, State* state_to,
                                        int event, void (*on_transition)())

--- a/Fsm.h
+++ b/Fsm.h
@@ -48,7 +48,7 @@ public:
   int add_timed_transition(State* state_from, State* state_to,
                             unsigned long interval, void (*on_transition)());
 
-  void Fsm::edit_timed_transition(unsigned long interval, int index)
+  void edit_timed_transition_interval(unsigned long interval, int index);
 
 
   void check_timed_transitions();

--- a/Fsm.h
+++ b/Fsm.h
@@ -45,6 +45,9 @@ public:
   void add_timed_transition(State* state_from, State* state_to,
                             unsigned long interval, void (*on_transition)());
 
+  void Fsm::edit_timed_transition(unsigned long interval, int index)
+
+
   void check_timed_transitions();
 
   void trigger(int event);

--- a/Fsm.h
+++ b/Fsm.h
@@ -48,8 +48,7 @@ public:
   int add_timed_transition(State* state_from, State* state_to,
                             unsigned long interval, void (*on_transition)());
 
-  void edit_timed_transition_interval(unsigned long interval, int index);
-
+  void edit_timed_transition_interval(int index, unsigned long interval);
 
   void check_timed_transitions();
 

--- a/Fsm.h
+++ b/Fsm.h
@@ -23,6 +23,9 @@
   #include <WProgram.h>
 #endif
 
+// error codes
+#define ERR_BAD_STATE -10
+
 
 struct State
 {
@@ -39,10 +42,10 @@ public:
   Fsm(State* initial_state);
   ~Fsm();
 
-  void add_transition(State* state_from, State* state_to, int event,
+  int add_transition(State* state_from, State* state_to, int event,
                       void (*on_transition)());
 
-  void add_timed_transition(State* state_from, State* state_to,
+  int add_timed_transition(State* state_from, State* state_to,
                             unsigned long interval, void (*on_transition)());
 
   void Fsm::edit_timed_transition(unsigned long interval, int index)


### PR DESCRIPTION
Changes made:
* Add a function to edit the interval of timed transitions
* Timed transitions are referred to by their positions in the m_transitions or m_timed_transitions arrays
  * The functions which create transitions now return this index so the user can store it for later
    * Returning a negative number indicates there was an error in creating the transition