### PR TITLE
introduce transition predicates

### DIFF
--- a/Fsm.h
+++ b/Fsm.h
@@ -18,13 +18,13 @@
 
 
 #if defined(ARDUINO) && ARDUINO >= 100
-  #include <Arduino.h>
+#include <Arduino.h>
 #else
-  #include <WProgram.h>
+#include <WProgram.h>
 #endif
 
 
-struct State
+struct State 
 {
   State(void (*on_enter)(), void (*on_state)(), void (*on_exit)());
   void (*on_enter)();
@@ -32,18 +32,23 @@ struct State
   void (*on_exit)();
 };
 
+bool _enabled(const State *from, const State *to);
 
-class Fsm
+typedef bool (*predicate)(const State *, const State *);
+
+class Fsm 
 {
 public:
-  Fsm(State* initial_state);
+  Fsm(State *initial_state);
   ~Fsm();
 
-  void add_transition(State* state_from, State* state_to, int event,
-                      void (*on_transition)());
+  void add_transition(State *state_from, State *state_to, int event,
+                      void (*on_transition)(),
+                      predicate precondition = _enabled);
 
-  void add_timed_transition(State* state_from, State* state_to,
-                            unsigned long interval, void (*on_transition)());
+  void add_timed_transition(State *state_from, State *state_to,
+                            unsigned long interval, void (*on_transition)(),
+                            predicate precondition = _enabled);
 
   void check_timed_transitions();
 
@@ -51,32 +56,33 @@ public:
   void run_machine();
 
 private:
-  struct Transition
+  struct Transition 
   {
-    State* state_from;
-    State* state_to;
+    State *state_from;
+    State *state_to;
     int event;
     void (*on_transition)();
-
+    predicate precondition;
   };
-  struct TimedTransition
+  struct TimedTransition 
   {
     Transition transition;
     unsigned long start;
     unsigned long interval;
   };
 
-  static Transition create_transition(State* state_from, State* state_to,
-                                      int event, void (*on_transition)());
+  static Transition create_transition(State *state_from, State *state_to,
+                                      int event, void (*on_transition)(),
+                                      predicate precondition);
 
-  void make_transition(Transition* transition);
+  void make_transition(Transition *transition);
 
 private:
-  State* m_current_state;
-  Transition* m_transitions;
+  State *m_current_state;
+  Transition *m_transitions;
   int m_num_transitions;
 
-  TimedTransition* m_timed_transitions;
+  TimedTransition *m_timed_transitions;
   int m_num_timed_transitions;
   bool m_initialized;
 };

--- a/examples/using_predicates/light_switch_with_predicate.ino
+++ b/examples/using_predicates/light_switch_with_predicate.ino
@@ -1,0 +1,67 @@
+#include "Fsm.h"
+
+// State machine variables
+#define FLIP_LIGHT_SWITCH 1
+
+State state_light_on(on_light_on_enter, NULL, &on_light_on_exit);
+State state_light_off(on_light_off_enter, NULL, &on_light_off_exit);
+Fsm fsm(&state_light_off);
+
+bool transition_enabled(const State *, const State *) 
+{ 
+  return millis() > 5000; 
+}
+
+// Transition callback functions
+void on_light_on_enter()
+{
+  Serial.println("Entering LIGHT_ON");
+}
+
+void on_light_on_exit()
+{
+  Serial.println("Exiting LIGHT_ON");
+}
+
+void on_light_off_enter()
+{
+  Serial.println("Entering LIGHT_OFF");
+}
+
+void on_light_off_exit()
+{
+  Serial.println("Exiting LIGHT_OFF");
+}
+
+void on_trans_light_on_light_off()
+{
+  Serial.println("Transitioning from LIGHT_ON to LIGHT_OFF");
+}
+
+void on_trans_light_off_light_on()
+{
+  Serial.println("Transitioning from LIGHT_OFF to LIGHT_ON");
+}
+
+// standard arduino functions
+void setup()
+{
+  Serial.begin(9600);
+
+  fsm.add_transition(&state_light_on, &state_light_off,
+                     FLIP_LIGHT_SWITCH,
+                     &on_trans_light_on_light_off);
+  fsm.add_transition(&state_light_off, &state_light_on,
+                     FLIP_LIGHT_SWITCH,
+                     &on_trans_light_off_light_on,
+                     transition_enabled);
+}
+
+void loop()
+{
+  // No "fsm.run_machine()" call needed as no "on_state" funcions or timmed transitions exists
+  delay(2000);
+  fsm.trigger(FLIP_LIGHT_SWITCH);
+  delay(2000);
+  fsm.trigger(FLIP_LIGHT_SWITCH);
+}


### PR DESCRIPTION
a transition or timed transition may optionally be guarded by a predicate.  The transition will fire only if the evaluation of the predicate returns true.

The using_predicates example shows how to dynamically enable/disable transitions at runtime.